### PR TITLE
include nrpe

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -49,6 +49,8 @@ define monitor::plugin (
   $enable      = true
   ) {
 
+  include nrpe
+  
   $bool_enable = any2bool($enable)
   $safe_name = regsubst($name, '(/| )', '_', 'G')
   $ensure = $bool_enable ? {


### PR DESCRIPTION
this module called nrpe varibles without the 'include nrpe' we can end up with monitor::plugin being called before nrpe::init and we end up with nrpe config files being created in /

(using puppet dashboard/ENC so can't include this in site.pp)
