### PR TITLE
Fixed issues with "parser = future"

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -71,7 +71,7 @@ define monitor::mount (
     }
   }
 
-  if ($tool =~ /nagios/) {
+  if ('nagios' in $tool) {
     nagios::service { "Mount_${escapedname}":
       ensure        => $computed_ensure,
       template      => $real_template,
@@ -79,7 +79,7 @@ define monitor::mount (
     }
   }
 
-  if ($tool =~ /icinga/) {
+  if ('icinga' in $tool) {
     icinga::service { "Mount_${escapedname}":
       ensure        => $computed_ensure,
       template      => $real_template,
@@ -87,7 +87,7 @@ define monitor::mount (
     }
   }
 
-  if ($tool =~ /puppi/) {
+  if ('puppi' in $tool) {
     puppi::check { "Mount_${escapedname}":
       enable   => $enable,
       hostwide => 'yes',

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -71,7 +71,7 @@ define monitor::plugin (
     remote  => "${plugin}!${arguments}",
   }
 
-  if ($tool =~ /nagios/) {
+  if ('nagios' in $tool) {
     include nrpe
 
     nagios::service { $safe_name:
@@ -95,7 +95,7 @@ define monitor::plugin (
     }
   }
 
-  if ($tool =~ /icinga/) {
+  if ('icinga' in $tool) {
     include nrpe
 
     icinga::service { $safe_name:
@@ -118,7 +118,7 @@ define monitor::plugin (
     }
   }
 
-  if ($tool =~ /puppi/) {
+  if ('puppi' in $tool) {
     puppi::check { $safe_name:
       enable   => $bool_enable,
       hostwide => 'yes',

--- a/manifests/port.pp
+++ b/manifests/port.pp
@@ -47,7 +47,7 @@ define monitor::port (
     udp => $udp_check_command,
   }
 
-  if ($tool =~ /nagios/) {
+  if ('nagios' in $tool) {
     nagios::service { $name:
       ensure        => $ensure,
       template      => $real_template,
@@ -56,7 +56,7 @@ define monitor::port (
     }
   }
 
-  if ($tool =~ /icinga/) {
+  if ('icinga' in $tool) {
     icinga::service { $name:
       ensure        => $ensure,
       template      => $real_template,
@@ -68,7 +68,7 @@ define monitor::port (
     'tcp' => "check_tcp -H ${target} -p ${port}" ,
     'udp' => "check_udp -H ${target} -p ${port}" ,
   }
-  if ($tool =~ /puppi/) {
+  if ('puppi' in $tool) {
     puppi::check { $name:
       enable   => $bool_enable,
       hostwide => 'yes',

--- a/manifests/process.pp
+++ b/manifests/process.pp
@@ -24,7 +24,7 @@ define monitor::process (
     true  => 'present',
   }
 
-  if ($tool =~ /monit/) {
+  if ('monit' in $tool) {
     monit::checkpid { $name:
       pidfile      => $pidfile,
       process      => "${process}${argument}",
@@ -34,7 +34,7 @@ define monitor::process (
     }
   }
 
-  if ($tool =~ /bluepill/) {
+  if ('bluepill' in $tool) {
     bluepill::process { $name:
       pidfile      => $pidfile,
       process      => "${process}${argument}",
@@ -45,7 +45,7 @@ define monitor::process (
     }
   }
 
-  if ($tool =~ /eye/) {
+  if ('eye' in $tool) {
     eye::process { $name:
       pidfile      => $pidfile,
       process      => "${process}${argument}",
@@ -67,7 +67,7 @@ define monitor::process (
     default => $default_check_command,
   }
 
-  if ($tool =~ /nagios/) {
+  if ('nagios' in $tool) {
     nagios::service { $name:
       ensure              => $ensure,
       service_description => $service_description,
@@ -76,7 +76,7 @@ define monitor::process (
     }
   }
 
-  if ($tool =~ /icinga/) {
+  if ('icinga' in $tool) {
     icinga::service { $name:
       ensure              => $ensure,
       service_description => $service_description,
@@ -96,7 +96,7 @@ define monitor::process (
     default => $puppi_default_command,
   }
 
-  if ($tool =~ /puppi/) {
+  if ('puppi' in $tool) {
     puppi::check { $name:
       enable   => $bool_enable,
       hostwide => 'yes',

--- a/manifests/url.pp
+++ b/manifests/url.pp
@@ -84,7 +84,7 @@ define monitor::url (
     default => $default_check_command
   }
 
-  if ($tool =~ /nagios/) {
+  if ('nagios' in $tool) {
     # Use for Example42 service checks
     # (note: are used custom Nagios and nrpe commands)
     nagios::service { $name:
@@ -95,7 +95,7 @@ define monitor::url (
     }
   }
 
-  if ($tool =~ /icinga/) {
+  if ('icinga' in $tool) {
     icinga::service { $name:
       ensure        => $ensure,
       template      => $real_template,
@@ -115,7 +115,7 @@ define monitor::url (
     default => "check_http -I '${computed_target}' -p '${port}' -u '${url}' -H '${computed_host}' -r '${pattern}' -a ${username}:${password} -A '${useragent}'" ,
   }
 
-  if ($tool =~ /puppi/) {
+  if ('puppi' in $tool) {
     # Use for Example42 puppi checks
     puppi::check { $name:
       enable   => $enable,


### PR DESCRIPTION
Running puppet 3.7+ with the option "parser = future" resulted in the following error:

Evaluation Error: Left match operand must result in a String value. Got an Array.

Fixed by changing the way matching in array is done.